### PR TITLE
rename VGER to Vger

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub struct LineMetrics {
     pub bounds: LocalRect,
 }
 
-pub struct VGER {
+pub struct Vger {
     scenes: [Scene; 3],
     cur_scene: usize,
     cur_layer: usize,
@@ -62,7 +62,7 @@ pub struct VGER {
     layout: Layout,
 }
 
-impl VGER {
+impl Vger {
     /// Create a new renderer given a device and output pixel format.
     pub fn new(device: &wgpu::Device, texture_format: wgpu::TextureFormat) -> Self {
         let shader = device.create_shader_module(&wgpu::ShaderModuleDescriptor {
@@ -516,26 +516,23 @@ impl VGER {
     }
 
     fn setup_layout(&mut self, text: &str, size: u32, max_width: Option<f32>) {
-
         let scale = self.device_px_ratio;
 
         self.layout.reset(&LayoutSettings {
-            max_width: max_width.map(|w| w*scale),
+            max_width: max_width.map(|w| w * scale),
             ..LayoutSettings::default()
         });
 
-        let scaled_size = size as f32 * scale; 
+        let scaled_size = size as f32 * scale;
 
         self.layout.append(
             &[&self.glyph_cache.font],
             &TextStyle::new(text, scaled_size, 0),
         );
-
     }
 
     /// Renders text.
     pub fn text(&mut self, text: &str, size: u32, color: Color, max_width: Option<f32>) {
-
         self.setup_layout(text, size, max_width);
 
         let padding = 2.0 as f32;
@@ -551,9 +548,7 @@ impl VGER {
         for glyph in self.layout.glyphs() {
             let c = text.chars().nth(i).unwrap();
             // println!("glyph {:?}", c);
-            let info = self
-                .glyph_cache
-                .get_glyph(c, scaled_size);
+            let info = self.glyph_cache.get_glyph(c, scaled_size);
 
             if let Some(rect) = info.rect {
                 let mut prim = Prim::default();
@@ -561,10 +556,10 @@ impl VGER {
                 prim.xform = xform;
                 assert!(glyph.width == rect.width as usize);
                 assert!(glyph.height == rect.height as usize);
-                
+
                 prim.quad_bounds = [
-                    (glyph.x-padding) / scale,
-                    (glyph.y-padding) / scale,
+                    (glyph.x - padding) / scale,
+                    (glyph.y - padding) / scale,
                     (glyph.x + padding + glyph.width as f32) / scale,
                     (glyph.y + padding + glyph.height as f32) / scale,
                 ];
@@ -595,7 +590,6 @@ impl VGER {
 
     /// Calculates the bounds for text.
     pub fn text_bounds(&mut self, text: &str, size: u32, max_width: Option<f32>) -> LocalRect {
-
         self.setup_layout(text, size, max_width);
 
         let mut min = LocalPoint::new(f32::MAX, f32::MAX);
@@ -605,7 +599,13 @@ impl VGER {
 
         for glyph in self.layout.glyphs() {
             min = min.min([glyph.x / scale, glyph.y / scale].into());
-            max = max.max([(glyph.x + glyph.width as f32) / scale, (glyph.y + glyph.height as f32) / scale ].into());
+            max = max.max(
+                [
+                    (glyph.x + glyph.width as f32) / scale,
+                    (glyph.y + glyph.height as f32) / scale,
+                ]
+                .into(),
+            );
         }
 
         LocalRect::new(min, (max - min).into())
@@ -623,13 +623,16 @@ impl VGER {
 
         self.setup_layout(text, size, max_width);
 
-        let s = 1.0/self.device_px_ratio;
+        let s = 1.0 / self.device_px_ratio;
 
         for glyph in self.layout.glyphs() {
-            rects.push(LocalRect::new(
-                [glyph.x, glyph.y].into(),
-                [glyph.width as f32, glyph.height as f32].into(),
-            ).scale(s, s))
+            rects.push(
+                LocalRect::new(
+                    [glyph.x, glyph.y].into(),
+                    [glyph.width as f32, glyph.height as f32].into(),
+                )
+                .scale(s, s),
+            )
         }
 
         rects
@@ -641,9 +644,8 @@ impl VGER {
         size: u32,
         max_width: Option<f32>,
     ) -> Vec<LineMetrics> {
-
         self.setup_layout(text, size, max_width);
-        let s = 1.0/self.device_px_ratio;
+        let s = 1.0 / self.device_px_ratio;
 
         let mut rects = vec![];
         rects.reserve(text.len());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -108,7 +108,7 @@ async fn create_png(
 }
 
 fn render_test(
-    vger: &mut VGER,
+    vger: &mut Vger,
     device: &wgpu::Device,
     queue: &wgpu::Queue,
     name: &str,
@@ -223,7 +223,7 @@ fn test_color_hex() {
 fn fill_circle() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
     let cyan = vger.color_paint(Color::CYAN);
@@ -236,7 +236,7 @@ fn fill_circle() {
 fn fill_circle_array() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
     let cyan = vger.color_paint(Color::CYAN);
@@ -252,7 +252,7 @@ fn fill_circle_array() {
 fn fill_circle_translate() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
     let cyan = vger.color_paint(Color::CYAN);
@@ -266,7 +266,7 @@ fn fill_circle_translate() {
 fn fill_rect() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
     let cyan = vger.color_paint(Color::CYAN);
@@ -279,7 +279,7 @@ fn fill_rect() {
 fn fill_rect_gradient() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -300,7 +300,7 @@ fn fill_rect_gradient() {
 fn stroke_rect_gradient() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -333,7 +333,7 @@ fn stroke_rect_gradient() {
 fn stroke_arc_gradient() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -361,7 +361,7 @@ fn stroke_arc_gradient() {
 fn segment_stroke_gradient() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -388,7 +388,7 @@ fn segment_stroke_gradient() {
 fn bezier_stroke_gradient() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -419,7 +419,7 @@ fn rand2<T: rand::Rng>(rng: &mut T) -> LocalPoint {
 fn path_fill() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -445,7 +445,7 @@ fn path_fill() {
 fn text() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -459,7 +459,7 @@ fn text() {
 fn text_small() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 
@@ -473,7 +473,7 @@ fn text_small() {
 fn text_scale() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 2.0);
 
@@ -487,7 +487,7 @@ fn text_scale() {
 fn text_box() {
     let (device, queue) = block_on(setup());
 
-    let mut vger = VGER::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut vger = Vger::new(&device, wgpu::TextureFormat::Rgba8UnormSrgb);
 
     vger.begin(512.0, 512.0, 1.0);
 


### PR DESCRIPTION
I think `Vger` follows more closely the Rust naming convention