### PR TITLE
Avoid loop during buffer resize

### DIFF
--- a/src/gpu_vec.rs
+++ b/src/gpu_vec.rs
@@ -47,13 +47,9 @@ impl<T: Copy> GPUVec<T> {
     /// We'd like to write directly to the mapped buffer, but that seemed
     /// tricky with wgpu.
     pub fn update(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) -> bool {
-        let mut realloc = false;
-        while self.data.len() > self.capacity {
-            self.capacity *= 2;
-            realloc = true;
-        }
-
+        let realloc = self.data.len() > self.capacity;
         if realloc {
+            self.capacity = self.data.len().next_power_of_two();
             self.buffer = device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some(self.label.as_str()),
                 size: (size_of::<T>() * self.capacity) as u64,


### PR DESCRIPTION
Just a minor improvement that avoids looping to find a 2's multiple of cap > len by using [next_power_of_two](https://doc.rust-lang.org/std/primitive.usize.html#method.next_power_of_two) instead, which is more idiomatic (and likely faster since it uses bit ops and some clever integer arithmetic).