### PR TITLE
Update to wgpu 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wgpu = "0.17.0"
+wgpu = "0.18.0"
 euclid = "0.22.7"
 fontdue = "0.7.2"
 rect_packer = "0.2.1"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -171,10 +171,12 @@ pub fn render_test(
             resolve_target: None,
             ops: wgpu::Operations {
                 load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                store: true,
+                store: wgpu::StoreOp::Store,
             },
         })],
         depth_stencil_attachment: None,
+        occlusion_query_set: None,
+        timestamp_writes: None,
     };
 
     vger.encode(&desc);


### PR DESCRIPTION
This picks up OpenGL support on Windows for better hardware support.