### PR TITLE
Update wgpu 0.20 -> 22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wgpu = "0.20.0"
+wgpu = "22"
 euclid = "0.22.7"
 fontdue = "0.9.0"
 rect_packer = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ impl Vger {
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
             multiview: None,
+            cache: None,
         });
 
         let layout = Layout::new(CoordinateSystem::PositiveYUp);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -21,6 +21,7 @@ pub async fn setup() -> (wgpu::Device, wgpu::Queue) {
                 label: None,
                 required_features: wgpu::Features::default(),
                 required_limits: wgpu::Limits::default(),
+                memory_hints: wgpu::MemoryHints::Performance,
             },
             trace_dir.ok().as_ref().map(std::path::Path::new),
         )


### PR DESCRIPTION
Once again, the steady march of progress...

wgpu released v22 about a month ago (dropping the "0." prefix and skipping 0.21). I'm updating all my applications to the new version, and vger-rs is a dependency.

Almost no changes were required to vger-rs. v22 of wgpu adds an optional shader cache object to `wgpu::RenderPipelineDescriptor` that we may want to use / expose at some point, but that's it.

However while upgrading wgpu doesn't affect our API, it is a breaking change for any downstream application which also makes use of wgpu, which is presumably most. So as before, we should bump vger-rs's release number to 0.4.